### PR TITLE
Fix some memory leaks reported by Xcode 16.1

### DIFF
--- a/Discord Lite/DLController.m
+++ b/Discord Lite/DLController.m
@@ -624,7 +624,7 @@ static DLController* sharedObject = nil;
         if (!m) {
             m = [[DLServerMember alloc] initWithDict:memberData];
             [[self loadedServerWithID:serverID] addMember:m];
-            [m release];
+            [m autorelease];
         }
         DLUser *u = [m user];
         if (u && (![u isEqual:myUser])) {

--- a/Discord Lite/DLDirectMessageChannel.m
+++ b/Discord Lite/DLDirectMessageChannel.m
@@ -115,7 +115,7 @@
             [matchedUsers addObject:user];
         }
     }
-    return matchedUsers;
+    return [matchedUsers autorelease];
 }
 
 - (NSComparisonResult)compare:(DLDirectMessageChannel *)o {

--- a/Discord Lite/DLMainWindowController.m
+++ b/Discord Lite/DLMainWindowController.m
@@ -760,6 +760,7 @@ const NSTimeInterval TYPING_SEND_INTERVAL = 8.0;
     NSMutableAttributedString *as = [[NSMutableAttributedString alloc] initWithString:baseString];
     [as addAttribute:NSFontAttributeName value:[NSFont boldSystemFontOfSize:13] range:[baseString rangeOfString:[[m author] username]]];
     [replyToTextField setAttributedStringValue:as];
+    [as release];
     [self showReplyToView];
 }
 -(BOOL)chatViewShouldBeginEditing:(ChatItemViewController *)chatView {

--- a/Discord Lite/DLMessageEditor.m
+++ b/Discord Lite/DLMessageEditor.m
@@ -135,7 +135,7 @@ const CGFloat MESSAGE_EDITOR_FONT_SIZE = 13.0;
     [m setContent:rawContent];
     [m setAttachments:attachments];
     [m setReferencedMessage:referencedMessage];
-    return m;
+    return [m autorelease];
 }
 
 -(void)clear {

--- a/Discord Lite/DLUserSettings.m
+++ b/Discord Lite/DLUserSettings.m
@@ -22,7 +22,7 @@
     NSEnumerator *e = [folderData objectEnumerator];
     NSDictionary *folder;
     while (folder = [e nextObject]) {
-        [tempFolders addObject:[[DLServerFolder alloc] initWithDict:folder]];
+        [tempFolders addObject:[[[DLServerFolder alloc] initWithDict:folder] autorelease]];
     }
     serverFolders = tempFolders;
     return self;

--- a/Discord Lite/DLUtil.m
+++ b/Discord Lite/DLUtil.m
@@ -67,7 +67,7 @@ static NSDictionary *superPropertiesDict;
         sysctl(mib, sizeof mib / sizeof(int), str, &size, NULL, 0);
         NSString *ret = [[NSString stringWithUTF8String:str] retain];
         free(str);
-        return ret;
+        return [ret autorelease];
     }
     return @"";
 }
@@ -80,8 +80,8 @@ static NSDictionary *superPropertiesDict;
     return randomString;
 }
 +(NSString *)mimeTypeForExtension:(NSString *)ext {
-    NSString *UTI = (NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (CFStringRef)ext, NULL);
-    NSString *mimeType = (NSString *)UTTypeCopyPreferredTagWithClass((CFStringRef)UTI, kUTTagClassMIMEType);
+    NSString *UTI = [(NSString*)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (CFStringRef)ext, NULL) autorelease];
+    NSString *mimeType = [(NSString*)UTTypeCopyPreferredTagWithClass((CFStringRef)UTI, kUTTagClassMIMEType) autorelease];
     if (!mimeType) {
         mimeType = @"application/octet-stream";
     }
@@ -113,14 +113,14 @@ static NSDictionary *superPropertiesDict;
     return date;
 }
 +(NSString *)userAgentString {
-    return [NSString stringWithFormat:@"DiscordLite/%@ CFNetwork/%@ Darwin/%@", [DLUtil appVersionString], [DLUtil networkVersionString], [DLUtil kernelVersion]];
+    return [[NSString stringWithFormat:@"DiscordLite/%@ CFNetwork/%@ Darwin/%@", [DLUtil appVersionString], [DLUtil networkVersionString], [DLUtil kernelVersion]] autorelease];
 }
 +(NSString *)superPropertiesString {
     if (!superPropertiesDict) {
         superPropertiesDict = [[NSDictionary alloc] initWithObjects:[NSArray arrayWithObjects:@"Mac OS X", @"Discord Client", @"stable", @"0.0.266", [DLUtil kernelVersion], @"x64", @"en-US", @"209354", [NSNull null], nil] forKeys:[NSArray arrayWithObjects:@"os", @"browser", @"release_channel", @"client_version", @"os_version", @"os_arch", @"system_locale", @"client_build_number", @"client_event_source", nil]];
     }
     NSData *serializedData = [[CJSONSerializer serializer] serializeDictionary:superPropertiesDict error:nil];
-    return [[NSString encodeBase64WithData:serializedData] autorelease];
+    return [NSString encodeBase64WithData:serializedData];
 }
 
 @end

--- a/Discord Lite/DLWSController.m
+++ b/Discord Lite/DLWSController.m
@@ -149,7 +149,7 @@ static size_t writecb(char *b, size_t size, size_t nitems, void *p) {
     [data setObject:[NSNumber numberWithBool:YES] forKey:@"typing"];
     [data setObject:[NSNumber numberWithBool:NO] forKey:@"activities"];
     [data setObject:[NSNumber numberWithBool:NO] forKey:@"threads"];
-    NSArray *channelInfo = [NSArray arrayWithObjects:[[NSArray alloc] initWithObjects:[NSNumber numberWithInt:0], [NSNumber numberWithInt:99], nil], nil];
+    NSArray *channelInfo = [NSArray arrayWithObjects:[NSArray arrayWithObjects:[NSNumber numberWithInt:0], [NSNumber numberWithInt:99], nil], nil];
     NSMutableDictionary *channels = [[NSMutableDictionary alloc] init];
     [channels setObject:channelInfo forKey:[c channelID]];
     NSMutableDictionary *d = [[NSMutableDictionary alloc] init];

--- a/Discord Lite/NSString+Base64.m
+++ b/Discord Lite/NSString+Base64.m
@@ -138,7 +138,7 @@ static const short _base64DecodingTable[256] = {
 	}
     
 	NSString *strToReturn = [[NSString alloc] initWithBytesNoCopy:strResult length:objPointer - strResult encoding:NSASCIIStringEncoding freeWhenDone:YES];
-	return strToReturn;
+	return [strToReturn autorelease];
 }
 
 @end

--- a/Discord Lite/NSTextView+Menu.m
+++ b/Discord Lite/NSTextView+Menu.m
@@ -45,7 +45,7 @@
             NSEnumerator *e = [[textViewContextMenu itemArray] objectEnumerator];
             NSMenuItem *item;
             while (item = [e nextObject]) {
-                [menu addItem:[item copy]];
+                [menu addItem:[[item copy] autorelease]];
             }
         }
     }

--- a/Discord Lite/ServerStatusIndicatorView.m
+++ b/Discord Lite/ServerStatusIndicatorView.m
@@ -57,6 +57,7 @@
     [path fill];
     [[NSColor whiteColor] set];
     [path stroke];
+	[path release];
 }
 
 -(void)drawHoverIndicator {
@@ -76,6 +77,7 @@
     [path fill];
     [[NSColor whiteColor] set];
     [path stroke];
+	[path release];
 }
 
 -(void)drawSelectedIndicator {
@@ -95,6 +97,7 @@
     [path fill];
     [[NSColor whiteColor] set];
     [path stroke];
+	[path release];
 }
 
 @end


### PR DESCRIPTION
Note: if older Xcode SDKs are lacking `CFBridgingRelease()`, `-[NSObject autorelease]` could be used instead (`CFBridgingRelease` is just `return [(id)CFMakeCollectable(X) autorelease]` under MRC. I don't know if Discord Lite uses Garbage Collection, but it doesn't look like it, so the call to `CFMakeCollectable()` wouldn't be needed). 